### PR TITLE
Expand backlog tasks with details

### DIFF
--- a/QUESTIONS.md
+++ b/QUESTIONS.md
@@ -5,3 +5,13 @@ Once the information has been integrated into the repo (docs or code), remove th
 
 - **Q:** What CSV column names do you expect for pump basal rate exports?
   **A:** _TBD_
+- **Q:** For the Dexcom API connector, which OAuth grant flow and API scopes should we implement?
+  **A:** _TBD_
+- **Q:** Should Nightscout imports support both treatments and sensor glucose endpoints?
+  **A:** _TBD_
+- **Q:** Do we have target thresholds for the overnight basal drift detector (e.g. mmol rise over 4 h)?
+  **A:** _TBD_
+- **Q:** When tagging exercise from Fitbit/Google Fit, what step-count thresholds classify moderate versus vigorous activity?
+  **A:** _TBD_
+- **Q:** For the linear BG prediction prototype, what error metric and acceptable accuracy define success?
+  **A:** _TBD_

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,20 +27,36 @@
 * [ ] **MVP‑03** `analysis`: add overnight basal drift detector
   *Helps flag basal mis‑settings before bolus advice.*
   *Docs*: update `README (Capabilities)` once merged.
+  *Details*: analyse BG trends between 00:00–05:00 to highlight rising or falling patterns.
+  *Acceptance*: unit tests cover typical, high and low drift scenarios; report lists nights with detected drift; docs describe usage.
 * [ ] **MVP‑04** `report`: include “events sampled / events skipped” stats block
   *Enhances transparency.*
+  *Details*: add section in Markdown and JSON summarising number of candidate events versus discarded ones.
+  *Acceptance*: stats appear in both output formats; tests verify counts; README updated.
 * [ ] **INT‑01** `ingest`: Dexcom real‑time API connector
   Link to Issue #12.
+  *Details*: pull glucose readings via Dexcom OAuth API and store tokens locally.
+  *Acceptance*: CLI flag `--dexcom` fetches data when credentials supplied; token refresh handled; mocked tests; docs updated.
 * [ ] **INT‑02** `ingest`: Nightscout REST importer
   Permits DIY Loop users to sync.  Requires token auth.
+  *Details*: fetch glucose, carbs and insulin data from a Nightscout instance using REST endpoints.
+  *Acceptance*: CLI `--nightscout URL` imports recent records with token auth; unit tests mock API; docs describe setup.
 * [ ] **INT‑03** `notify`: weekly summary email (SendGrid)
   Funnel: `analysis → Jinja → email`.  Add opt‑in flag to CLI.
+  *Details*: generate email from Jinja template summarising last week's metrics and send via SendGrid.
+  *Acceptance*: CLI `--email ADDRESS` sends summary when SendGrid key configured; tests mock network calls; README outlines opt‑in.
 * [ ] **CTX‑01** `context`: Fitbit/Google Fit step detector
   Mark exercise windows in analysis.
+  *Details*: import step counts from Fitbit or Google Fit to tag moderate/vigorous activity periods.
+  *Acceptance*: analysis marks exercise segments when step data provided; tests cover sample files; docs list expected columns.
 * [ ] **ADV‑01** `ml`: prototype simple linear BG prediction
   Use last 30 clean meals to fit sensitivity model.
+  *Details*: implement regression predicting BG 2 h after meal based on carbs and insulin.
+  *Acceptance*: model trains locally; prediction error reported in output; unit tests with synthetic data; docs explain limitations.
 * [ ] **DEV‑tooling** `ci`: add doc‑sync checker
   Fails CI if README not touched when CLI changes.
+  *Details*: CI step verifies commits modifying `cli.py` also modify `README.md`.
+  *Acceptance*: checker runs in GitHub Actions and blocks merge on mismatch; contributing docs mention the rule.
 
 ## 🚧 In Progress
 


### PR DESCRIPTION
## Summary
- elaborate backlog entries with detailed descriptions and acceptance criteria
- add follow-up product questions about upcoming features

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python -m bg_analyzer --help`


------
https://chatgpt.com/codex/tasks/task_e_6841746d3638832bb6cbc47a3b371093