### PR TITLE
Implement generic CSV loader

### DIFF
--- a/bg_analyzer/cli.py
+++ b/bg_analyzer/cli.py
@@ -7,6 +7,8 @@ import sys
 
 import click
 
+from .ingest import load_csv
+
 
 @click.command()
 @click.option(
@@ -31,16 +33,18 @@ def main(
 ) -> None:
     """Run analysis on provided CSV files.
 
-    This placeholder prints the file paths and exits. Actual
-    analysis will be implemented later.
+    The parser currently validates the expected columns only.
     """
 
     click.echo("BG Analyzer skeleton")
     if glucose:
+        load_csv(glucose, ["timestamp", "bg_mmol"])
         click.echo(f"Glucose file: {glucose}")
     if insulin:
+        load_csv(insulin, ["timestamp", "bolus_units", "bolus_type"])
         click.echo(f"Insulin file: {insulin}")
     if carbs:
+        load_csv(carbs, ["timestamp", "carbs_grams", "meal_label"])
         click.echo(f"Carb file: {carbs}")
 
     sys.exit(0)

--- a/bg_analyzer/ingest/__init__.py
+++ b/bg_analyzer/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Data ingestion utilities."""
+
+from .csv_loader import load_csv
+
+__all__ = ["load_csv"]

--- a/bg_analyzer/ingest/csv_loader.py
+++ b/bg_analyzer/ingest/csv_loader.py
@@ -1,0 +1,41 @@
+"""CSV loading utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+def load_csv(path: Path, required_columns: Iterable[str]) -> pd.DataFrame:
+    """Load a CSV file and validate required columns.
+
+    Parameters
+    ----------
+    path : Path
+        File path of the CSV to load.
+    required_columns : Iterable[str]
+        Column names that must be present in the file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Parsed DataFrame with columns sorted as in the file.
+
+    Raises
+    ------
+    ValueError
+        If any required column is missing.
+    """
+    df = pd.read_csv(path)
+
+    missing = [col for col in required_columns if col not in df.columns]
+    if missing:
+        raise ValueError(f"Missing columns in {path}: {', '.join(missing)}")
+
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        df = df.sort_values("timestamp")
+
+    return df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path when running `pytest`
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from bg_analyzer.ingest import load_csv
+
+SAMPLES = Path(__file__).resolve().parent.parent / "samples"
+
+
+def test_load_csv_success():
+    df = load_csv(SAMPLES / "glucose.csv", ["timestamp", "bg_mmol"])
+    assert not df.empty
+    assert list(df.columns) == ["timestamp", "bg_mmol"]
+    assert pd.api.types.is_datetime64_any_dtype(df["timestamp"])
+
+
+def test_load_csv_missing_column(tmp_path: Path):
+    file = tmp_path / "bad.csv"
+    file.write_text("timestamp\n2024-01-01T00:00:00")
+    with pytest.raises(ValueError):
+        load_csv(file, ["timestamp", "bg_mmol"])


### PR DESCRIPTION
## Summary
- implement `load_csv` utility for ingestion
- integrate loader in CLI
- ensure tests run without installing package
- test loading of required columns

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python -m bg_analyzer --help`

------
https://chatgpt.com/codex/tasks/task_e_684178ed4150832ba8ca344e4dc914d0