### PR TITLE
Docs update for task status requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Welcome, autonomous agent!  This document explains the project layout, coding co
    * Title = concise, imperative.
    * Body = *What + Why + How*, link the issue.
    * Checklist ticked (tests, docs, coverage).
+   * Update `ROADMAP.md` task status in the same PR (move card or tick box).
    * Tag `@maintainers` for review.
 
 ---

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ All heavy computation runs **locally**; nothing is sent to external servers unle
 1. **Open an issue** to discuss ideas or bugs.
 2. **Fork & PR** – follow the conventional‑commits style for concise commit messages.
 3. **Pre‑commit hooks** run formatting & tests (`pre‑commit install`).
-4. **Need clarification?** Add a bullet to `QUESTIONS.md` so the product owner can respond.
+4. **Update `ROADMAP.md`** – move your task card or tick its checkbox in the same PR so everyone sees current status.
+5. **Need clarification?** Add a bullet to `QUESTIONS.md` so the product owner can respond.
 
 If you live with T1D, your real‑world feedback is invaluable—please share how the tool could fit (or already fits) into your routine.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,7 @@
 > * Keep descriptions short; link to an Issue/PR for details.
 > * When a task alters user‑visible behaviour or CLI flags, **update the docs** (`README.md`, `agents.md`, samples) in the same PR.
 > * Add yourself as owner with `@handle` so everyone knows who’s on it.
+> * **Always update the task card's status in the same PR**—move it or tick the box so the board stays current.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify in README that contributors must update `ROADMAP.md`
- instruct agents in `AGENTS.md` to modify their task card in the PR
- document the same requirement at the top of `ROADMAP.md`

## Testing
- `pre-commit run --files README.md AGENTS.md ROADMAP.md`
- `pytest -q`
- `python bg_analyzer/cli.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68417fbf96a4832ba19bfa03fe944bc0