### PR TITLE
Improve test coverage across analysis modules

### DIFF
--- a/tests/test_basal_drift.py
+++ b/tests/test_basal_drift.py
@@ -31,3 +31,16 @@ def test_classify_drift_falling():
     df = _make_data([-2.5, -3.0, -2.0])
     entries = calculate_drift(df)
     assert classify_drift(entries) == "falling"
+
+
+def test_calculate_drift_values():
+    df = _make_data([1.0])
+    entries = calculate_drift(df)
+    assert len(entries) == 1
+    assert entries[0].delta_mmol == 1.0
+
+
+def test_classify_drift_insufficient():
+    df = _make_data([1.0, 1.0])
+    entries = calculate_drift(df)
+    assert classify_drift(entries, days=3) == "insufficient-data"

--- a/tests/test_clean_events.py
+++ b/tests/test_clean_events.py
@@ -36,3 +36,112 @@ def test_find_clean_events_simple():
     assert evt.bolus_units == 2.0
     assert evt.pre_bg_mmol == 5.6
     assert evt.post_bg_mmol == 7.0
+
+
+def test_find_clean_events_multiple_bolus():
+    glucose = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z", "2024-01-01T10:00:00Z"],
+            "bg_mmol": [5.6, 7.0],
+        }
+    )
+    insulin = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T07:55:00Z", "2024-01-01T08:05:00Z"],
+            "bolus_units": [1.0, 1.0],
+            "bolus_type": ["meal", "meal"],
+        }
+    )
+    carbs = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z"],
+            "carbs_grams": [20],
+            "meal_label": ["Breakfast"],
+        }
+    )
+
+    events = find_clean_events(glucose, insulin, carbs)
+    assert events == []
+
+
+def test_find_clean_events_later_bolus():
+    glucose = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z", "2024-01-01T10:00:00Z"],
+            "bg_mmol": [5.6, 7.0],
+        }
+    )
+    insulin = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z", "2024-01-01T08:30:00Z"],
+            "bolus_units": [2.0, 1.0],
+            "bolus_type": ["meal", "meal"],
+        }
+    )
+    carbs = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z"],
+            "carbs_grams": [20],
+            "meal_label": ["Breakfast"],
+        }
+    )
+
+    events = find_clean_events(glucose, insulin, carbs)
+    assert events == []
+
+
+def test_find_clean_events_unstable_bg():
+    glucose = pd.DataFrame(
+        {
+            "timestamp": [
+                "2024-01-01T07:40:00Z",
+                "2024-01-01T07:55:00Z",
+                "2024-01-01T08:00:00Z",
+                "2024-01-01T10:00:00Z",
+            ],
+            "bg_mmol": [5.0, 7.0, 7.2, 9.0],
+        }
+    )
+    insulin = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z"],
+            "bolus_units": [2.0],
+            "bolus_type": ["meal"],
+        }
+    )
+    carbs = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z"],
+            "carbs_grams": [20],
+            "meal_label": ["Breakfast"],
+        }
+    )
+
+    events = find_clean_events(glucose, insulin, carbs)
+    assert events == []
+
+
+def test_find_clean_events_needs_post_bg():
+    glucose = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T07:55:00Z", "2024-01-01T08:00:00Z"],
+            "bg_mmol": [5.5, 5.6],
+        }
+    )
+    insulin = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z"],
+            "bolus_units": [2.0],
+            "bolus_type": ["meal"],
+        }
+    )
+    carbs = pd.DataFrame(
+        {
+            "timestamp": ["2024-01-01T08:00:00Z"],
+            "carbs_grams": [20],
+            "meal_label": ["Breakfast"],
+        }
+    )
+
+    events = find_clean_events(glucose, insulin, carbs)
+    assert events == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,40 @@ def test_cli_help():
     )
     assert result.returncode == 0
     assert "BG Analyzer skeleton" not in result.stdout
+
+
+def test_cli_with_files(tmp_path):
+    g = tmp_path / "glucose.csv"
+    g.write_text("timestamp,bg_mmol\n2024-01-01T00:00Z,6.0\n")
+    i = tmp_path / "insulin.csv"
+    # fmt: off
+    i.write_text(
+        "timestamp,bolus_units,bolus_type\n"
+        "2024-01-01T00:00Z,1.0,meal\n"
+    )
+    c = tmp_path / "carbs.csv"
+    c.write_text(
+        "timestamp,carbs_grams,meal_label\n"
+        "2024-01-01T00:00Z,10,Breakfast\n"
+    )
+    # fmt: on
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "bg_analyzer",
+            "--glucose",
+            str(g),
+            "--insulin",
+            str(i),
+            "--carbs",
+            str(c),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert f"Glucose file: {g}" in result.stdout
+    assert f"Insulin file: {i}" in result.stdout
+    assert f"Carb file: {c}" in result.stdout


### PR DESCRIPTION
## Summary
- add edge case coverage for `find_clean_events`
- verify drift calculations and insufficient-data cases
- exercise CLI execution with sample files

## Testing
- `pre-commit run --all-files`
- `pytest -q`
- `python bg_analyzer/cli.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68418b6001fc832b8b388acf408337e8